### PR TITLE
Bugfix/linecoverage

### DIFF
--- a/lib/simplecov_small_badge/formatter.rb
+++ b/lib/simplecov_small_badge/formatter.rb
@@ -51,11 +51,6 @@ module SimpleCovSmallBadge
       end
     end
 
-    def line_coverage_minimum
-      minimums = SimpleCov.minimum_coverage
-      minimums.is_a?(Hash) ? minimums[:line] : minimums
-    end
-
     def map_image_config(state)
       hash = {}
       @config.to_hash.map do |key, value|

--- a/lib/simplecov_small_badge/formatter.rb
+++ b/lib/simplecov_small_badge/formatter.rb
@@ -33,14 +33,21 @@ module SimpleCovSmallBadge
     end
 
     def state(covered_percent)
-      if line_coverage_minimum&.positive?
-        if covered_percent >= line_coverage_minimum
+      if coverage_minimum&.positive?
+        if covered_percent >= coverage_minimum
           'good'
         else
           'bad'
         end
       else
         'unknown'
+      end
+    end
+
+    def coverage_minimum
+      @coverage_minimum ||= begin
+        minimums = SimpleCov.minimum_coverage
+        minimums.is_a?(Hash) ? minimums[SimpleCov.primary_coverage] : minimums
       end
     end
 


### PR DESCRIPTION
First time I tried the gem I got an error that `.positive?` is not a method on Hash.

I traced this back to an error with the method:

```
def line_coverage_minimum
      minimums = SimpleCov.minimum_coverage
      minimums.is_a?(Hash) ? minimums[:line] : minimums
    end
```

Where seemingly the shape of `SimpleCov.minimum_coverage` had maybe changed or was not what the last line of the method expected.

Looking at the open issues and the PRs on the gem, someone already [solved this issue with a PR](https://github.com/MarcGrimme/simplecov-small-badge/pull/16), but the PR has not been merged and this gem seems to not be maintained. Note, despite this being unmaintained, it feels generally low risk, and will keep an eye on depandabot alerts for any security concerns.


As a result, forked this gem and leveraged this authors suggested update: https://github.com/MarcGrimme/simplecov-small-badge/pull/16